### PR TITLE
Fix crash if an episode has no image

### DIFF
--- a/tvmaze.bundle/Contents/Code/__init__.py
+++ b/tvmaze.bundle/Contents/Code/__init__.py
@@ -210,7 +210,7 @@ class TVmazeAgent(Agent.TV_Shows):
             # Download the episode thumbnail
             valid_names = list()
 
-            if ep.image.get('original'):
+            if ep.image is not None and ep.image.get('original'):
                 thumb_url = ep.image.get('original')
                 if thumb_url is not None and len(thumb_url) > 0:
                     # Check that the thumb doesn't already exist before downloading it


### PR DESCRIPTION
I found that only the first episode of a show I tried was getting metadata. After checking the logs, I found the following error:

`2020-04-08 18:47:19,265 (7fcf8ffff700) :  DEBUG (runtime:717) - Handling request GET /:/plugins/com.plexapp.agents.tvmaze/messaging/function/X0FnZW50S2l0OlVwZGF0ZU1ldGFkYXRh/Y2VyZWFsMQoxCmxpc3QKMApyMAo_/Y2VyZWFsMQoxCmRpY3QKMTAKczIKZW5zNApsYW5nYjFzNQpmb3JjZWIwczgKcGVyaW9kaWNzNQoxMTYwNXM0CmRiaWRpMApzNwp2ZXJzaW9ubnMxMApwYXJlbnRHVUlEbnM4CnBhcmVudElEczcKVFZfU2hvd3MxMAptZWRpYV90eXBlczQwCmNvbS5wbGV4YXBwLmFnZW50cy50dm1hemU6Ly8yNTE1P2xhbmc9ZW5zNApndWlkczQKMjUxNXMyCmlkcjAK2020-04-08 18:47:19,269 (7fcf8ffff700) :  DEBUG (runtime:49) - Received packed state data (584 bytes)2020-04-08 18:47:19,278 (7fcf8ffff700) :  DEBUG (runtime:814) - Found route matching /:/plugins/com.plexapp.agents.tvmaze/messaging/function/X0FnZW50S2l0OlVwZGF0ZU1ldGFkYXRh/Y2VyZWFsMQoxCmxpc3QKMApyMAo_/Y2VyZWFsMQoxCmRpY3QKMTAKczIKZW5zNApsYW5nYjFzNQpmb3JjZWIwczgKcGVyaW9kaWNzNQoxMTYwNXM0CmRiaWRpMApzNwp2ZXJzaW9ubnMxMApwYXJlbnRHVUlEbnM4CnBhcmVudElEczcKVFZfU2hvd3MxMAptZWRpYV90eXBlczQwCmNvbS5wbGV4YXBwLmFnZW50cy50dm1hemU6Ly8yNTE1P2xhbmc9ZW5zNApndWlkczQKMjUxNXMyCmlkcjAK2020-04-08 18:47:19,283 (7fcf8ffff700) :  DEBUG (model:32) - Loading model with GUID com.plexapp.agents.tvmaze://2515?lang=en
2020-04-08 18:47:19,284 (7fcf8ffff700) :  DEBUG (model:234) - Deserializing from /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Metadata/TV Shows/e/8b3d970a5dca9b656bb04d2b48d481ecc9ef94f.bundle/Contents/com.plexapp.agents.tvmaze/Info.xml
2020-04-08 18:47:19,296 (7fcf8ffff700) :  DEBUG (networking:143) - Requesting 'http://127.0.0.1:32400/library/metadata/11605/tree'
2020-04-08 18:47:19,351 (7fcf8ffff700) :  DEBUG (__init__:86) - Update() called...
2020-04-08 18:47:19,549 (7fcf8ffff700) :  DEBUG (networking:143) - Requesting 'http://static.tvmaze.com/uploads/images/original_untouched/13/33589.jpg'
2020-04-08 18:47:19,639 (7fcf8ffff700) :  DEBUG (networking:143) - Requesting 'http://static.tvmaze.com/uploads/images/original_untouched/13/33589.jpg'
2020-04-08 18:47:19,701 (7fcf8ffff700) :  DEBUG (networking:143) - Requesting 'http://static.tvmaze.com/uploads/images/original_untouched/13/33589.jpg'
2020-04-08 18:47:19,764 (7fcf8ffff700) :  DEBUG (networking:143) - Requesting 'http://static.tvmaze.com/uploads/images/original_untouched/13/33589.jpg'2020-04-08 18:47:19,812 (7fcf8ffff700) :  DEBUG (networking:143) - Requesting 'http://static.tvmaze.com/uploads/images/original_untouched/13/33589.jpg'
2020-04-08 18:47:20,006 (7fcf8ffff700) :  CRITICAL (agentkit:1091) - Exception in the update function of agent named 'TVmaze', called with guid 'com.plexapp.agents.tvmaze://2515?lang=en' (most recent call last):
  File "/usr/lib/plexmediaserver/Resources/Plug-ins-513b381af/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/api/agentkit.py", line 1089, in _update  
    agent.update(obj, media, lang, **kwargs)
  File "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-ins/tvmaze.bundle/Contents/Code/__init__.py", line 213, in update
    if ep.image.get('original'):
AttributeError: 'NoneType' object has no attribute 'get'
2020-04-08 18:47:20,028 (7fcf8ffff700) :  DEBUG (model:229) - Serializing to /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Metadata/TV Shows/e/8b3d970a5dca9b656bb04d2b48d481ecc9ef94f.bundle/Contents/com.plexapp.agents.tvmaze/Info.xml
2020-04-08 18:47:20,031 (7fcf8ffff700) :  DEBUG (runtime:88) - Sending packed state data (610 bytes)
2020-04-08 18:47:20,032 (7fcf8ffff700) :  DEBUG (runtime:924) - Response: [200] str, 16 bytes`

I realised that the error on this line meant that the episode info for the first episode was getting populated but then the rest wouldn't be as a result of this crash. I added a None check for ep.image and then all the metadata was retrieved